### PR TITLE
Fixing null element access

### DIFF
--- a/probable_adblock.js
+++ b/probable_adblock.js
@@ -104,7 +104,7 @@ function adBlockNodes(nodes, adElementSelector) {
       let adstory = node.closest(adElementSelector)
       
       // Preventing same adstory to be handled more than once
-      if (adstory.getAttribute('adblocked') === 'true') {
+      if (!adstory || adstory.getAttribute('adblocked') === 'true') {
           continue;
       }
       


### PR DESCRIPTION
**Changes**
- Checking if element is null before trying to use it, to prevent error "TypeError: null is not an object (evaluating 'adstory.getAttribute')"

Even with this error the Ads on Youtube were blocked, but sometimes they appeared again.